### PR TITLE
Added 'extern "C"' modifiers for mixed C/C++

### DIFF
--- a/kernel/atom.h
+++ b/kernel/atom.h
@@ -33,6 +33,10 @@
 #include "atomtimer.h"
 #include "atomport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Data types */
 
 /* Forward declaration */
@@ -121,6 +125,10 @@ extern void archThreadContextInit (ATOM_TCB *tcb_ptr, void *stack_top, void (*en
 extern void archFirstThreadRestore(ATOM_TCB *new_tcb_ptr);
 
 extern void atomTimerTick (void);
+
+#ifdef __cplusplus
+}
+#endif
 
 
 #endif /* __ATOM_H */

--- a/kernel/atommutex.h
+++ b/kernel/atommutex.h
@@ -29,6 +29,10 @@
 #ifndef __ATOM_MUTEX_H
 #define __ATOM_MUTEX_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct atom_mutex
 {
     ATOM_TCB *  suspQ;  /* Queue of threads suspended on this mutex */
@@ -40,5 +44,9 @@ extern uint8_t atomMutexCreate (ATOM_MUTEX *mutex);
 extern uint8_t atomMutexDelete (ATOM_MUTEX *mutex);
 extern uint8_t atomMutexGet (ATOM_MUTEX *mutex, int32_t timeout);
 extern uint8_t atomMutexPut (ATOM_MUTEX *mutex);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ATOM_MUTEX_H */

--- a/kernel/atomport-template.h
+++ b/kernel/atomport-template.h
@@ -31,6 +31,10 @@
 #define __ATOM_PORT_H
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Required number of system ticks per second (normally 100 for 10ms tick) */
 #define SYSTEM_TICKS_PER_SEC            100
 
@@ -73,6 +77,10 @@
 
 /* Uncomment to enable stack-checking */
 /* #define ATOM_STACK_CHECKING */
+
+#ifdef __cplusplus
+}
+#endif
 
 
 #endif /* __ATOM_PORT_H */

--- a/kernel/atomqueue.h
+++ b/kernel/atomqueue.h
@@ -29,6 +29,10 @@
 #ifndef __ATOM_QUEUE_H
 #define __ATOM_QUEUE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct atom_queue
 {
     ATOM_TCB *  putSuspQ;       /* Queue of threads waiting to send */
@@ -45,5 +49,9 @@ extern uint8_t atomQueueCreate (ATOM_QUEUE *qptr, uint8_t *buff_ptr, uint32_t un
 extern uint8_t atomQueueDelete (ATOM_QUEUE *qptr);
 extern uint8_t atomQueueGet (ATOM_QUEUE *qptr, int32_t timeout, uint8_t *msgptr);
 extern uint8_t atomQueuePut (ATOM_QUEUE *qptr, int32_t timeout, uint8_t *msgptr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ATOM_QUEUE_H */

--- a/kernel/atomsem.h
+++ b/kernel/atomsem.h
@@ -30,6 +30,10 @@
 #ifndef __ATOM_SEM_H
 #define __ATOM_SEM_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct atom_sem
 {
     ATOM_TCB *  suspQ;  /* Queue of threads suspended on this semaphore */
@@ -41,5 +45,9 @@ extern uint8_t atomSemDelete (ATOM_SEM *sem);
 extern uint8_t atomSemGet (ATOM_SEM *sem, int32_t timeout);
 extern uint8_t atomSemPut (ATOM_SEM *sem);
 extern uint8_t atomSemResetCount (ATOM_SEM *sem, uint8_t count);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ATOM_SEM_H */

--- a/kernel/atomtimer.h
+++ b/kernel/atomtimer.h
@@ -32,6 +32,10 @@
 
 #include "atomport.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 /* Callback function prototype */
 typedef void ( * TIMER_CB_FUNC ) ( POINTER cb_data ) ;
@@ -57,5 +61,9 @@ extern uint8_t atomTimerCancel (ATOM_TIMER *timer_ptr);
 extern uint8_t atomTimerDelay (uint32_t ticks);
 extern uint32_t atomTimeGet (void);
 extern void atomTimeSet (uint32_t new_time);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ATOM_TIMER_H */

--- a/ports/avr/atomport-private.h
+++ b/ports/avr/atomport-private.h
@@ -30,10 +30,18 @@
 #ifndef __ATOM_PORT_PRIVATE_H
 #define __ATOM_PORT_PRIVATE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* CPU Frequency */
 #define AVR_CPU_HZ          1000000
 
 /* Function prototypes */
 void avrInitSystemTickTimer ( void );
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __ATOM_PORT_PRIVATE_H */

--- a/ports/avr/atomport.h
+++ b/ports/avr/atomport.h
@@ -40,6 +40,10 @@
 /* Definition of NULL is available from stddef.h on this platform */
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Required number of system ticks per second (normally 100 for 10ms tick) */
 #define SYSTEM_TICKS_PER_SEC            100
 
@@ -67,6 +71,10 @@
 
 /* Uncomment to enable stack-checking */
 /* #define ATOM_STACK_CHECKING */
+
+#ifdef __cplusplus
+}
+#endif
 
 
 #endif /* __ATOM_PORT_H */

--- a/ports/avr/uart.h
+++ b/ports/avr/uart.h
@@ -13,6 +13,9 @@
 
 #include "atom.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /*
  * Perform UART startup initialization.
@@ -23,3 +26,8 @@ int	uart_init(uint32_t baudrate);
  * Send one character to the UART.
  */
 int	uart_putchar(char c, FILE *stream);
+
+#ifdef __cplusplus
+}
+#endif
+


### PR DESCRIPTION
Hello.

While my first attempt to use AtomThreads with standard Arduino UNO I found that function declarations aren't exported as "C" functions. So, there is simple changes in kernel and avr port to add them.

Sorry, I didn't change other ports just because I don't have other hardware to test it.
## 

Regards,
Vasily
