### PR TITLE
Fix problem with re-adding timer in callback

### DIFF
--- a/kernel/atomtimer.c
+++ b/kernel/atomtimer.c
@@ -488,6 +488,13 @@ static void atomTimerCallbacks (void)
         next_ptr = callback_list_head;
         while (next_ptr)
         {
+            /* If the cb_func re-registers the timer, it will be prepended
+             * to the timer_queue. Save next_timer pointer here, otherwise we
+             * might end up processing the timer_queue instead of the callback
+             * list.
+             */
+            saved_next_ptr = next_ptr->next_timer;
+
             /* Call the registered callback */
             if (next_ptr->cb_func)
             {
@@ -495,7 +502,7 @@ static void atomTimerCallbacks (void)
             }
 
             /* Move on to the next callback in the list */
-            next_ptr = next_ptr->next_timer;
+            next_ptr = saved_next_ptr;
         }
     }
 


### PR DESCRIPTION
When processing timer callbacks, atomTimerCallbacks() removes due
timers from the timer_queue and puts them in a callback list.
If a callback calls atomTimerRegister() for itself, the timer gets
prepended to the timer_queue. On return, the callback processing
will continue in the timer_queue instead of the callback list.
Fixed by saving a pointer to the next entry in the callback list
before calling the cb_func.

Fixes #17  