### PR TITLE
[avr] allow changing AVR_CPU_HZ without modifying source tree

### DIFF
--- a/ports/avr/atomport-private.h
+++ b/ports/avr/atomport-private.h
@@ -31,7 +31,9 @@
 #define __ATOM_PORT_PRIVATE_H
 
 /* CPU Frequency */
+#ifndef AVR_CPU_HZ
 #define AVR_CPU_HZ          1000000
+#endif
 
 /* Function prototypes */
 void avrInitSystemTickTimer ( void );


### PR DESCRIPTION
This allows a build system to more simply build against atomthreads by overriding the HZ value via a compiler command line flag, rather than by embedding and modifying the atomthreads sources.